### PR TITLE
Release Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,68 +16,45 @@ Using `jq` this script manipulates fragments of JSON into a complete template be
 The following environment variables control what's built:
 
 * `OS`: Corresponds to the operating system template in [`os`](./os), can be `centos` or `ubuntu`.
-* `OS_RELEASE`: Corresponds to the operating system release used, e.g., `7.4` for [CentOS](./os/centos) or `trusty` for [Ubuntu](./os/ubuntu).
+* `OS_RELEASE`: Corresponds to the operating system release used, e.g., `7.5` for [CentOS](./os/centos) or `bionic` for [Ubuntu](./os/ubuntu).
 * `POST_PROCESSOR`: The [`post-processor`](./post-processor) to use:
   * `vagrant`: This is the default, creates a Vagrant box in the `output` directory.
   * `vagrant-cloud`: Creates a vagrant box and uploads it Vagrant Cloud.
   * `amazon-import`: Creates an OVA that is imported as an AMI using the AWS VM Import service.
+* `PROVISIONER`:  The [`provisioner`](./provisoner) installs additional software:
+  * [`default`](./provisioner/default.json): The default provisioner does nothing.
+  * [`hoot`](./provisioner/hoot.json): Prepares the host with packages necessary to install and test [Hootenanny](https://github.com/ngageoint/hootenanny/).
 
 Any additional command-line arguments are passed directly to `packer` which is useful for customization of [user variables](https://www.packer.io/docs/templates/user-variables.html).  For example:
 
 ```sh
 OS=ubuntu ./build.sh \
-  -var 'vm_name=trusty' \
+  -var 'vm_name=bionic' \
   -var 'headless=true' \
   -var 'disk_size=81920' \
   -var-file ~/my-variables.json
 ```
 
-## Examples
+## `release.sh`
 
-Examples are provided below of how this repository was used to generate their respective boxes on Vagrant Cloud.
+This script is a wrapper for `build.sh` that automatically sets up proper variables for the release versions of Hootenanny Vagrant Cloud boxes.  Examples are provided below of how this repository was used to generate the specific boxes.  All examples assume proper AWS and Vagrant Cloud credentials are in the environment:
+
+```sh
+export AWS_ACCESS_KEY_ID=AAAABBBBCCCC
+export AWS_SECRET_ACCESS_KEY=secret
+export VAGRANT_CLOUD_TOKEN=AAABBBCCC
+```
+
+AWS credentials must satisfy Amazon's [VM Import/Export Requirements](https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html).
 
 ### `hoot/centos7-minimal`
 
-VirtualBox provided:
-
 ```sh
-OS=centos OS_RELEASE=7.4 POST_PROCESSOR=vagrant-cloud ./build.sh \
-  -var 'vm_name=centos7-minimal' \
-  -var 'box_tag=hoot/centos7-minimal' \
-  -var 'access_token=AAABBBCCC'
-```
-
-AWS-provided:
-
-```sh
-OS=centos OS_RELEASE=7.4 POST_PROCESSOR=amazon-import ./build.sh \
-  -var 'vm_name=centos7-minimal' \
-  -var 'ami_description=CentOS 7 Minimal' \
-  -var 'region=us-east-1' \
-  -var 's3_bucket_name=my-bucket' \
-  -var 'access_key=AAAABBBBCCCC' \
-  -var 'secret_key=secret'
+./release.sh -n centos7-minimal -i my-bucket
 ```
 
 ### `hoot/trusty-minimal`
 
-VirtualBox provided:
-
 ```sh
-OS=ubuntu OS_RELEASE=trusty POST_PROCESSOR=vagrant-cloud ./build.sh \
-  -var 'vm_name=trusty-minimal' \
-  -var 'box_tag=hoot/trusty-minimal' \
-  -var 'access_token=AAABBBCCC'
-```
-
-AWS provided:
-
-```sh
-OS=ubuntu OS_RELEASE=trusty POST_PROCESSOR=amazon-import ./build.sh \
-  -var 'vm_name=trusty-minimal' \
-  -var 'ami_description=Ubuntu 14.04 Minimal' \
-  -var 'region=us-east-1' \
-  -var 's3_bucket_name=my-bucket' \
-  -var 'access_key=AAAABBBBCCCC' \
-  -var 'secret_key=secret'
+./release.sh -n trusty-minimal -i my-bucket
 ```

--- a/provisioner/hoot.json
+++ b/provisioner/hoot.json
@@ -5,7 +5,8 @@
            "environment_vars": [
            ],
            "scripts": [
-               "scripts/centos/hoot-provision.sh"
+               "scripts/centos/hoot-provision.sh",
+               "scripts/common/zerofree.sh"
            ]
        }
     ]

--- a/release.sh
+++ b/release.sh
@@ -28,6 +28,9 @@ while getopts ":i:n:t:u:v:" opt; do
         t)
             VAGRANT_CLOUD_TOKEN_FILE="$OPTARG"
             ;;
+        u)
+            VAGRANT_CLOUD_USER="$OPTARG"
+            ;;
         v)
             BOX_VERSION="$OPTARG"
             ;;
@@ -145,7 +148,6 @@ curl \
     --output "$BOX_DIR/box-create.json" \
     https://app.vagrantup.com/api/v1/boxes
 
-
 if [ -n "$(jq -M -r -s '(if .[0].name? then .[0].name else "" end)' "$BOX_DIR/box-create.json")" ]; then
     echo "Created $VAGRANT_CLOUD_USER/$BOX_NAME on Vagrant Cloud."
 fi
@@ -160,7 +162,6 @@ OS=$OS OS_RELEASE=$OS_RELEASE POST_PROCESSOR=vagrant-cloud PROVISIONER=$PROVISIO
    -var "memsize=$MEMSIZE" \
    -var 'ssh_wait_timeout=90m' \
    -var "access_token=$VAGRANT_CLOUD_TOKEN"
-
 
 # Generate AWS-provided Vagrant box.
 OS=$OS OS_RELEASE=$OS_RELEASE POST_PROCESSOR=amazon-import PROVISIONER=$PROVISIONER \

--- a/release.sh
+++ b/release.sh
@@ -141,7 +141,7 @@ curl \
     --silent --show-error \
     --header "Content-Type: application/json" \
     --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-    --data "{ \"box\": { \"username\": \"$VAGRANT_CLOUD_USER\", \"name\": \"$BOX_NAME\" } }" \
+    --data "{ \"box\": { \"username\": \"$VAGRANT_CLOUD_USER\", \"name\": \"$BOX_NAME\", \"is_private\": false } }" \
     --output "$BOX_DIR/box-create.json" \
     https://app.vagrantup.com/api/v1/boxes
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+set -euo pipefail
+
+# Default values.
+AMI_DISK_SIZE=8192
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
+BOX_VERSION="$(date +%Y%m%d).0.0"
+BOX_NAME=""
+MEMSIZE=512
+PROVISIONER=default
+REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+USAGE="no"
+VAGRANT_CLOUD_TOKEN="${VAGRANT_CLOUD_TOKEN:-}"
+VAGRANT_CLOUD_TOKEN_FILE=""
+VAGRANT_CLOUD_USER="hoot"
+VMIMPORT_BUCKET=""
+
+while getopts ":i:n:t:u:v:" opt; do
+    case "$opt" in
+        i)
+            VMIMPORT_BUCKET="$OPTARG"
+            ;;
+        n)
+            BOX_NAME="$OPTARG"
+            ;;
+        t)
+            VAGRANT_CLOUD_TOKEN_FILE="$OPTARG"
+            ;;
+        v)
+            BOX_VERSION="$OPTARG"
+            ;;
+        *)
+            USAGE=yes
+            ;;
+    esac
+done
+
+# Document the usage for this script.
+function usage() {
+    echo "release.sh -n <Box Name> -i <VM Import S3 Bucket>"
+    echo "  [-t <Vagrant Cloud Token JSON file>]"
+    echo "  [-u <Vagrant Cloud User, default: '$VAGRANT_CLOUD_USER'>"
+    echo "  [-v <Box Version, default: '$BOX_VERSION'>]"
+    echo ""
+    echo "  This script requires Vagrant Cloud and AWS credentials."
+    echo "  AWS credentials may be specified in in ~/.aws/credentials or the"
+    echo "  \$AWS_ACCESS_KEY_ID and \$AWS_SECRET_ACCESS_KEY environment"
+    echo "  variables. The credentials must have IAM privileges to use the"
+    echo "  AWS VM Import/Export service on the provided VM Import S3 Bucket."
+    echo ""
+    echo "  The Vagrant Cloud token may be provided via a JSON file with an"
+    echo "  'access_token' key (-t option) or the \$VAGRANT_CLOUD_TOKEN "
+    echo "  environment variable."
+    exit 1
+}
+
+# If AWS credentials aren't passed in via environment variables, attempt
+# to get them using the CLI tools.
+if [ -z "$AWS_ACCESS_KEY_ID" -o -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    if [ -x "$(which aws)" ]; then
+        AWS_ACCESS_KEY_ID="$(aws configure get aws_access_key_id || true)"
+        AWS_SECRET_ACCESS_KEY="$(aws configure get aws_secret_access_key || true)"
+    fi
+fi
+
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    printf "Error: AWS_ACCESS_KEY_ID is undefined.\n\n"
+    USAGE=yes
+fi
+
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    printf "Error: AWS_SECRET_ACCESS_KEY is undefined.\n\n"
+    USAGE=yes
+fi
+
+# Retrieve the Vagrant Cloud token from a JSON file that has an 'access_token'
+# key (e.g., it could be used as a `-var-file` Packer argument).
+if [ -f "$VAGRANT_CLOUD_TOKEN_FILE" ]; then
+    VAGRANT_CLOUD_TOKEN="$(jq -M -r -s '(if .[0].access_token? then .[0].access_token else "" end)' "$VAGRANT_CLOUD_TOKEN_FILE")"
+fi
+
+if [ -z "$VAGRANT_CLOUD_TOKEN" ]; then
+    printf "Error: VAGRANT_CLOUD_TOKEN is undefined.\n\n"
+    USAGE=yes
+fi
+
+# Checking required arguments.
+if [ -z "$BOX_NAME" ]; then
+    printf "Error: Box name not provided.\n\n"
+    USAGE=yes
+fi
+
+if [ -z "$VMIMPORT_BUCKET" ]; then
+    printf "Error: VM Import S3 Bucket not provided.\n\n"
+    USAGE=yes
+fi
+
+if [ "$USAGE" = "yes" ]; then
+    usage
+fi
+
+case "$BOX_NAME" in
+    centos7-hoot)
+        AMI_DESCRIPTION="CentOS 7 Hootenanny v$BOX_VERSION"
+        AMI_DISK_SIZE=12288
+        MEMSIZE=4096
+        PROVISIONER=hoot
+        OS=centos
+        OS_RELEASE=7.5
+        ;;
+    centos7-minimal)
+        AMI_DESCRIPTION="CentOS 7 Minimal v$BOX_VERSION"
+        OS=centos
+        OS_RELEASE=7.5
+        ;;
+    bionic-minimal)
+        AMI_DESCRIPTION="Ubuntu 18.04 (bionic) Minimal v$BOX_VERSION"
+        OS=ubuntu
+        OS_RELEASE=bionic
+        ;;
+    trusty-minimal)
+        AMI_DESCRIPTION="Ubuntu 14.04 (trusty) Minimal v$BOX_VERSION"
+        OS=ubuntu
+        OS_RELEASE=trusty
+        ;;
+    *)
+        echo "Do not know how to create a release for $BOX_NAME."
+        exit 1
+        ;;
+esac
+
+# Generate VirtualBox-provided Vagrant box.
+echo OS=$OS OS_RELEASE=$OS_RELEASE POST_PROCESSOR=vagrant-cloud PROVISIONER=$PROVISIONER \
+   ./build.sh \
+   -var "vm_name=$BOX_NAME" \
+   -var "box_tag=hoot/$BOX_NAME" \
+   -var "box_version=$BOX_VERSION" \
+   -var 'headless=true' \
+   -var "memsize=$MEMSIZE" \
+   -var 'ssh_wait_timeout=90m' \
+   -var "access_token=$VAGRANT_CLOUD_TOKEN"
+
+# Temporary directory for AWS-box files.
+BOX_DIR="$(mktemp -d)"
+
+# Generate AWS-provided Vagrant box.
+echo OS=$OS OS_RELEASE=$OS_RELEASE POST_PROCESSOR=amazon-import PROVISIONER=$PROVISIONER \
+  ./build.sh \
+  -var "vm_name=$BOX_NAME" \
+  -var "ami_description=$AMI_DESCRIPTION" \
+  -var "box_version=$BOX_VERSION" \
+  -var "disk_size=$AMI_DISK_SIZE" \
+  -var 'headless=true' \
+  -var "memsize=$MEMSIZE" \
+  -var "region=$REGION" \
+  -var 'ssh_wait_timeout=90m' \
+  -var "s3_bucket_name=$VMIMPORT_BUCKET" \
+  -var "access_key=$AWS_ACCESS_KEY_ID" \
+  -var "secret_key=$AWS_SECRET_ACCESS_KEY" | tee "$BOX_DIR/packer-build.log"
+
+# Determine the AMI ID from the build log.
+BOX_AMI="$(awk '{ if ($1 ~ /^us-east-1:/ ) print $2 }' < "$BOX_DIR/packer-build.log")"
+if [ -z "$BOX_AMI" ]; then
+    echo "Could not determine AMI from packer log: $BOX_DIR/packer-build.log"
+    exit 1
+fi
+
+# Create box tarball with correct metadata.json and Vagrantfile.
+pushd "$BOX_DIR"
+
+cat > metadata.json <<EOF
+{
+    "provider": "aws"
+}
+EOF
+
+cat > Vagrantfile <<EOF
+Vagrant.configure('2') do |config|
+  config.vm.provider :aws do |aws|
+    aws.region_config '$REGION', ami: '$BOX_AMI'
+  end
+end
+EOF
+
+tar -czf aws.box metadata.json Vagrantfile
+popd
+
+# The base URL for the releases.
+VAGRANT_URL="https://vagrantcloud.com/api/v1/box/$VAGRANT_CLOUD_USER/$BOX_NAME/version/$BOX_VERSION"
+
+# Create aws provider for the new box version.
+curl \
+  --header "Content-Type: application/json" \
+  --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
+  "$VAGRANT_URL/providers" \
+  --data '{ "provider": { "name": "aws" } }'
+
+# Get the upload path for the new aws-provided box.
+UPLOAD_RESPONSE="$(curl --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" "$VAGRANT_URL/provider/aws/upload")"
+UPLOAD_PATH="$(echo "$UPLOAD_RESPONSE" | jq -M -r -s '(if .[0].upload_path? then .[0].upload_path else "" end)')"
+
+if [ -n "$UPLOAD_PATH" ]; then
+    # Upload the box and finalize the release.
+    curl \
+        "$UPLOAD_PATH" \
+        --request PUT \
+        --upload-file "$BOX_DIR/aws.box"
+    curl \
+        --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
+        "$VAGRANT_URL/release" \
+        --request PUT
+
+    # Clean up box directory.
+    rm -fr "$BOX_DIR"
+
+    # All done!
+    exit 0
+else
+    # Something happened, keep temp files around.
+    echo "No upload path retrieved, examine log and files in $BOX_DIR."
+    exit 1
+fi

--- a/scripts/common/sshd.sh
+++ b/scripts/common/sshd.sh
@@ -23,7 +23,7 @@ if [ -f /etc/os-release ]; then
     source /etc/os-release
     if [ "$NAME" = "Ubuntu" ]; then
         # Upstart script on Ubuntu 14.04 to automatically generate SSH keys.
-        if [ "$VERSION_CODENAME" = "trusty" ]; then
+        if [ "${VERSION_ID:-}" = "14.04" ]; then
             cat > /etc/init/ssh-keygen.conf <<EOF
 description "OpenSSH HostKey Generation"
 
@@ -45,7 +45,7 @@ end script
 EOF
         fi
         # Systemd unit on Ubuntu 18.04 to automatically generate SSH keys.
-        if [ "$VERSION_CODENAME" = "bionic" ]; then
+        if [ "${VERSION_CODENAME:-}" = "bionic" ]; then
             cat > /lib/systemd/system/ssh-keygen.service <<EOF
 [Unit]
 Description=OpenSSH Server Key Generation


### PR DESCRIPTION
This automates the Vagrant Box release process with a `release.sh` script, including creating a new release on Vagrant Cloud and creating an AWS-provided box that uses the built AMI from the VM Import service.  It requires:

* Vagrant Cloud Token
* AWS Credentials (with VM Import/Export privileges)
* AWS S3 Bucket for use by VM Import/Export service

Additional minor edits including zero-filling disk space after Hootenanny provisioning and Ubuntu distribution identification fixes were added.